### PR TITLE
fix：停留在点击进入页面时无法继续执行

### DIFF
--- a/assets/resource/base/pipeline/startup.json
+++ b/assets/resource/base/pipeline/startup.json
@@ -2,7 +2,9 @@
     "StartUp": {
         "next": [
             "Flag_主界面任务",
-            "MihoyoSlogan"
+            "MihoyoSlogan",
+            "Flag_点击进入",
+            "Flag_更新版本"
         ],
         "interrupt": [
             "Click_关闭奖励弹窗",


### PR DESCRIPTION
和之前的 [issue#2](https://github.com/Coxwtwo/MaaTOT/pull/2) 一样，问题原因：
当启动游戏和启动Maa有时间差时，StartUp 执行时可能会错过 MihoyoSlogan 节点，此时如果没有将后续节点放到 next 列表中，会一直执行 interrupt 流程。interrupt 执行到最后一个 StartTOT 时，由于此时游戏本来就在运行，运行模拟器不会响应，又回头检测 MihoyoSlogan 节点，循环往复。

正好今天触发更新版本，也有这个问题：
![image](https://github.com/user-attachments/assets/98c8f3d2-a73e-4017-8c4b-0e1f3a4e8c5a)

